### PR TITLE
Add api v2 declaration to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ require "auth0"
 
 auth0 = Auth0Client.new(
   :token => "YOUR JWT HERE",
-  :domain => "<YOUR ACCOUNT>.auth0.com"
+  :domain => "<YOUR ACCOUNT>.auth0.com",
+  :api_version => 2
 )
 
 puts auth0.get_users


### PR DESCRIPTION
initialization will fail without explicit v2 declaration
